### PR TITLE
Refactor: Rename aoc_health to aoc_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,16 @@ ngrok http 8000
 
 ## Available Tools
 
-- `aoc_health()` - Health check and case count
+- `aoc_info()` - Get server info, supported languages, and agent instructions
 - `aoc_list_cases(year?, day?, part?)` - List cases with optional filters
 - `aoc_get_case(name, include?)` - Get case details
 - `aoc_eval(name, language, code)` - Evaluate user code against a case
 
 ## Example Usage
 
-### Health Check
+### Server Info
 ```json
-{"tool_name":"aoc_health","arguments":{}}
+{"tool_name":"aoc_info","arguments":{}}
 ```
 
 ### List Cases
@@ -126,6 +126,17 @@ ngrok http 8000
 - No network access
 - Non-root user execution
 - Configurable timeout limits
+
+## Language-Specific Configurations
+
+### Go
+- Uses a temporary filesystem at `/tmp` with execution permissions
+- Required for Go's compilation process and temporary file operations
+- Configured via `--tmpfs /tmp:exec` Docker option
+
+### Python
+- Runs in read-only environment
+- No additional filesystem modifications required
 
 ## Adding Test Cases
 

--- a/server/main.py
+++ b/server/main.py
@@ -18,21 +18,21 @@ CONTRACT_TEXT = (
 )
 
 @mcp.tool
-def aoc_health() -> dict:
-    """Health & contract info for agents."""
+def aoc_info() -> dict:
+    """Get server info, supported languages, and agent instructions."""
     return {
         "ok": True,
         "cases": len(ds.all),
         "server": NAME,
         "supported_languages": SUPPORTED_LANGUAGES,
-        "contract": CONTRACT_TEXT,
+        "agent_instructions": CONTRACT_TEXT,
     }
 
 @mcp.tool
 def aoc_list_cases(year: Optional[int]=None, day: Optional[int]=None, part: Optional[int]=None) -> dict:
     """List cases; optional filters year/day/part."""
     items = ds.list(year=year, day=day, part=part)
-    return {"items": items, "total": len(items)}
+    return {"items": items, "total": len(items), "agent_instructions": CONTRACT_TEXT}
 
 @mcp.tool
 def aoc_get_case(name: str) -> dict:
@@ -49,6 +49,7 @@ def aoc_get_case(name: str) -> dict:
         "day": c.day,
         "part": c.part,
         "task": c.task,
+        "agent_instructions": CONTRACT_TEXT,
     }
 
 @mcp.tool
@@ -74,6 +75,7 @@ def aoc_eval(name: str, language: Literal[*SUPPORTED_LANGUAGES], code: str) -> d
         "got": got,
         "exit_code": rc,
         "language": language,
+        "agent_instructions": CONTRACT_TEXT,
     }
     # Helpful guidance on failure
     if not passed:

--- a/server/main.py
+++ b/server/main.py
@@ -17,9 +17,14 @@ CONTRACT_TEXT = (
     "and print ONLY the final answer to stdout. Stdin is NOT provided."
 )
 
-@mcp.tool
+@mcp.tool()
 def aoc_info() -> dict:
-    """Get server info, supported languages, and agent instructions."""
+    """
+    Get server info, supported languages, and agent instructions.
+    
+    Returns:
+        Dictionary containing server status, case count, supported languages, and instructions
+    """
     return {
         "ok": True,
         "cases": len(ds.all),
@@ -28,17 +33,36 @@ def aoc_info() -> dict:
         "agent_instructions": CONTRACT_TEXT,
     }
 
-@mcp.tool
-def aoc_list_cases(year: Optional[int]=None, day: Optional[int]=None, part: Optional[int]=None) -> dict:
-    """List cases; optional filters year/day/part."""
+@mcp.tool()
+def aoc_list_cases(year: Optional[int] = None, day: Optional[int] = None, part: Optional[int] = None) -> dict:
+    """
+    List available Advent of Code cases with optional filtering.
+    
+    Args:
+        year: Filter by specific year (e.g., 2017, 2018)
+        day: Filter by specific day (1-25)
+        part: Filter by specific part (1 or 2)
+    
+    Returns:
+        Dictionary containing filtered cases and total count
+    """
     items = ds.list(year=year, day=day, part=part)
     return {"items": items, "total": len(items), "agent_instructions": CONTRACT_TEXT}
 
-@mcp.tool
-def aoc_get_case(name: str) -> dict:
+@mcp.tool()
+def aoc_get_case(name: str, include: Optional[List[str]] = None) -> dict:
     """
-    Get only the case metadata and task text.
-    Input and answer are intentionally NOT exposed by this API.
+    Get case metadata and task description for a specific case.
+    
+    Args:
+        name: The case identifier (e.g., "day1_part1_2017")
+        include: Optional list of fields to include (ignored, for compatibility)
+    
+    Returns:
+        Dictionary with case metadata and task description, or error if not found
+    
+    Note:
+        Input and answer are intentionally NOT exposed by this endpoint.
     """
     c = ds.get(name)
     if not c:
@@ -52,13 +76,22 @@ def aoc_get_case(name: str) -> dict:
         "agent_instructions": CONTRACT_TEXT,
     }
 
-@mcp.tool
+@mcp.tool()
 def aoc_eval(name: str, language: Literal[*SUPPORTED_LANGUAGES], code: str) -> dict:
     """
-    Evaluate user code for a case.
-
-    CONTRACT: Your code must read the input from './input.txt' and print ONLY the answer to stdout.
-    Stdin is NOT provided.
+    Evaluate user code against a specific Advent of Code case.
+    
+    Args:
+        name: The case identifier (e.g., "day1_part1_2017")
+        language: Programming language ("python" or "go")
+        code: The complete source code to evaluate
+    
+    Returns:
+        Dictionary with evaluation results including pass/fail status, output, and any errors
+    
+    CONTRACT:
+        Your code must read the input from './input.txt' and print ONLY the answer to stdout.
+        Stdin is NOT provided.
     """
     c = ds.get(name)
     if not c:


### PR DESCRIPTION
As a follow-up to improving the visibility of agent instructions, the `aoc_health` function has been renamed to `aoc_info`.

This new name more accurately reflects the function's purpose, which is to provide not just a health check, but also server metadata, supported languages, and agent instructions. The docstring has also been updated to align with this change.