### PR TITLE
feat: Add support for Ruby language

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ pip install -r requirements.txt
 docker build -t aocjudge-go -f docker/go.Dockerfile .
 docker build -t aocjudge-py -f docker/python.Dockerfile .
 docker build -t aocjudge-js -f docker/javascript.Dockerfile .
+docker build -t aocjudge-rb -f docker/ruby.Dockerfile .
 ```
 
 ### 3. Configure Environment
@@ -136,6 +137,10 @@ ngrok http 8000
 - Configured via `--tmpfs /tmp:exec` Docker option
 
 ### Python
+- Runs in read-only environment
+- No additional filesystem modifications required
+
+### Ruby
 - Runs in read-only environment
 - No additional filesystem modifications required
 

--- a/docker/ruby.Dockerfile
+++ b/docker/ruby.Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:3.2-alpine
+RUN adduser -D -s /bin/sh runner
+USER runner
+WORKDIR /app
+ENTRYPOINT ["ruby","/app/main.rb"]

--- a/server/langs.py
+++ b/server/langs.py
@@ -6,6 +6,7 @@ LANGS = {
     "go":         {"image": "aocjudge-go", "code_filename": "main.go"},
     "python":     {"image": "aocjudge-py", "code_filename": "main.py"},
     "javascript": {"image": "aocjudge-js", "code_filename": "main.js"},
+    "ruby":       {"image": "aocjudge-rb", "code_filename": "main.rb"},
 }
 
 SUPPORTED_LANGUAGES = sorted(LANGS.keys())


### PR DESCRIPTION
This commit introduces support for executing Ruby code in the judge.

- A new Dockerfile is added at `docker/ruby.Dockerfile` to create a sandboxed Ruby execution environment based on the `ruby:3.2-alpine` image.
- The `server/langs.py` configuration is updated to include "ruby", mapping it to the `aocjudge-rb` Docker image and the `main.rb` filename.
- The `README.md` is updated with instructions for building the new Ruby Docker image and documenting it as a supported language.