### PR TITLE
feat: Add performance metrics to aoc_eval response

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -97,7 +97,7 @@ def aoc_eval(name: str, language: Literal[*SUPPORTED_LANGUAGES], code: str) -> d
     if not c:
         return {"error": f"case not found: {name}"}
 
-    rc, out, err = run_code(language, code, c.input)
+    rc, out, err, metrics = run_code(language, code, c.input)
 
     got = (out or "").strip()
     expected = str(c.answer).strip()
@@ -108,6 +108,7 @@ def aoc_eval(name: str, language: Literal[*SUPPORTED_LANGUAGES], code: str) -> d
         "got": got,
         "exit_code": rc,
         "language": language,
+        "metrics": metrics,
         "agent_instructions": CONTRACT_TEXT,
     }
     # Helpful guidance on failure

--- a/server/runner.py
+++ b/server/runner.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
-import os, tempfile, subprocess
+import os, tempfile, subprocess, json
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Dict, Any
 from langs import LANGS
+from datetime import datetime
 
 DEFAULT_TIMEOUT_S = int(os.getenv("AOCJUDGE_TIMEOUT_MS", "8000")) / 1000.0  # seconds
 
@@ -10,9 +11,19 @@ def _write_files(tmp: Path, code_filename: str, code: str, input_data: str):
     (tmp / code_filename).write_text(code, encoding="utf-8")
     (tmp / "input.txt").write_text(input_data, encoding="utf-8")
 
-def _run_container(image: str, workdir: Path, language: str):
-    cmd = [
-        "docker", "run", "--rm",
+def _parse_docker_time(s: str) -> datetime | None:
+    # Docker's timestamps are RFC3339 with nanoseconds, but Python's fromisoformat
+    # before 3.11 doesn't handle 'Z' for UTC.
+    if not s or s.startswith("0001-01-01"):
+        return None
+    if s.endswith('Z'):
+        s = s[:-1] + '+00:00'
+    return datetime.fromisoformat(s)
+
+def _run_container(image: str, workdir: Path, language: str) -> Tuple[int, str, str, Dict[str, Any]]:
+    # Base command for docker create
+    create_cmd = [
+        "docker", "create",
         "--network", "none",
         "--memory", "256m",
         "--cpus", "0.5",
@@ -21,28 +32,73 @@ def _run_container(image: str, workdir: Path, language: str):
         "-w", "/app",
     ]
     if language in {"rust", "d"}:
-        cmd.extend(["--tmpfs", "/tmp:exec,size=64m"])
-    cmd.append(image)
+        create_cmd.extend(["--tmpfs", "/tmp:exec,size=64m"])
+    create_cmd.append(image)
+
     try:
-        # IMPORTANT: No stdin is provided. Code must read ./input.txt.
+        container_id = subprocess.check_output(create_cmd, stderr=subprocess.PIPE, text=True, encoding="utf-8").strip()
+    except subprocess.CalledProcessError as e:
+        return 127, "", e.stderr, {}
+
+    rc, out, err, metrics = 1, "", "", {}
+    try:
+        # Start container and wait for it to finish
+        start_cmd = ["docker", "start", "-a", container_id]
         proc = subprocess.run(
-            cmd,
+            start_cmd,
             input=None,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             timeout=DEFAULT_TIMEOUT_S,
             check=False,
         )
-        return proc.returncode, proc.stdout.decode("utf-8", "replace"), proc.stderr.decode("utf-8", "replace")
-    except subprocess.TimeoutExpired:
-        return 124, "", "timeout"
+        rc = proc.returncode
+        out = proc.stdout.decode("utf-8", "replace")
+        err = proc.stderr.decode("utf-8", "replace")
 
-def run_code(language: str, code: str, input_data: str):
+    except subprocess.TimeoutExpired:
+        rc, out, err = 124, "", "timeout"
+        # The container might still be running, so we should stop it.
+        subprocess.run(["docker", "stop", container_id], check=False, capture_output=True)
+
+    finally:
+        # Inspect container to get stats
+        inspect_cmd = ["docker", "inspect", container_id]
+        try:
+            inspect_proc = subprocess.run(inspect_cmd, capture_output=True, check=True)
+            inspect_data = json.loads(inspect_proc.stdout)[0]
+
+            started_at = _parse_docker_time(inspect_data["State"]["StartedAt"])
+            finished_at = _parse_docker_time(inspect_data["State"]["FinishedAt"])
+
+            duration_ms = None
+            if started_at and finished_at:
+                duration_ms = (finished_at - started_at).total_seconds() * 1000
+
+            metrics = {
+                "duration_ms": duration_ms,
+                "oom_killed": inspect_data["State"]["OOMKilled"],
+                "memory_limit_bytes": inspect_data["HostConfig"]["Memory"],
+            }
+
+        except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError, IndexError, TypeError) as e:
+            error_message = f"\nError inspecting container: {e}"
+            if not err:
+                err = error_message
+            else:
+                err += error_message
+
+        # Remove container
+        rm_cmd = ["docker", "rm", "-f", container_id]
+        subprocess.run(rm_cmd, check=False, capture_output=True)
+
+    return rc, out, err, metrics
+
+def run_code(language: str, code: str, input_data: str) -> Tuple[int, str, str, Dict[str, Any]]:
     cfg = LANGS.get(language)
     if not cfg:
-        return 127, "", f"unsupported language: {language}"
+        return 127, "", f"unsupported language: {language}", {}
     with tempfile.TemporaryDirectory(prefix=f"aocjudge-{language}-") as d:
         tmp = Path(d)
         _write_files(tmp, cfg["code_filename"], code, input_data)
-        rc, out, err = _run_container(cfg["image"], tmp, language)
-        return rc, out, err
+        return _run_container(cfg["image"], tmp, language)


### PR DESCRIPTION
This change modifies the code execution logic to capture performance metrics from the Docker container run.

The `aoc_eval` tool now includes a `metrics` object in its response, containing:
- `duration_ms`: The execution time of the container in milliseconds.
- `oom_killed`: A boolean indicating if the process was killed due to an out-of-memory error.
- `memory_limit_bytes`: The memory limit set for the container.

To achieve this, the `docker run` command was replaced with a sequence of `docker create`, `docker start`, `docker inspect`, and `docker rm` to allow for inspecting the container after it has finished.